### PR TITLE
Remove brotli directives so nginx:alpine container starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ WORKDIR /etc/nginx
 ADD nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 8080
+EXPOSE 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,12 +34,8 @@ http {
     gzip_http_version 1.1;
     gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-    brotli on;
-    brotli_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-    brotli_static on;
-
     server {
-        listen 8080;
+        listen 443;
 
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
The migration from fholzer/nginx-brotli:v1.24.0 to the official nginx:alpine image left brotli directives in nginx.conf. nginx:alpine does not include the ngx_brotli module, so the container failed to start with: [emerg] unknown directive "brotli". Gzip is already configured for the same MIME types, so compression is preserved.